### PR TITLE
Set reported on issue creation.

### DIFF
--- a/issue_tracker/app/models.py
+++ b/issue_tracker/app/models.py
@@ -39,9 +39,9 @@ class Issue(models.Model):
     priority = models.CharField(max_length=20, choices=PRIORITIES)
     project = models.CharField(max_length=100, blank=True, choices=PROJECTS)
     # Dates
-    submitted_date = models.DateField(auto_now_add=True, editable=False)
-    modified_date = models.DateField(auto_now=True)
-    closed_date = models.DateField(null=True, editable=False)
+    submitted_date = models.DateTimeField(auto_now_add=True, editable=False)
+    modified_date = models.DateTimeField(auto_now=True)
+    closed_date = models.DateTimeField(null=True, editable=False)
     # Users
     reporter = models.ForeignKey(auth_models.User, related_name='reporter',
                                  null=True)

--- a/issue_tracker/app/views.py
+++ b/issue_tracker/app/views.py
@@ -1,6 +1,7 @@
 """Container for the various views supported."""
 
 from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 from django.template import loader
 from django.template import RequestContext
 from django.views.generic import DetailView
@@ -21,15 +22,18 @@ class ExampleView(TemplateView):
         return self.render_to_response(context)
 
 
-# TODO(jdarrieu): reporter is not populating yet, needs to be fixed.
 class CreateIssue(CreateView):
     model = it_models.Issue
     fields = ['title', 'description', 'issue_type', 'priority', 'project',
               'assignee']
     template_name = 'create_issue.html'
 
-    def get_initial(self):
-        return {"user": self.request.user}
+    def form_valid(self, form):
+        new_issue = form.save(commit=False)
+        new_issue.reporter = self.request.user
+        new_issue.date_modified = el
+        new_issue.save()
+        return HttpResponseRedirect(new_issue.get_absolute_url())
 
 
 class ViewIssue(DetailView):

--- a/templates/issue_detail.html
+++ b/templates/issue_detail.html
@@ -1,8 +1,8 @@
 {% block content %}
 <h2>Issue: {{issue.pk}}: {{ issue }}</h2>
  <ul>
-   <li>Created: {{ issue.submitted_date }} by {{ issue.creator }}</a></li>
-   <li>Last updated: {{ issue.date_modified|timesince }} ago</li>
+   <li>Created: {{ issue.submitted_date }} by <a href="mailto:{{issue.reporter.email }}">{{ issue.reporter }}</a></li>
+   <li>Last modified: {{ issue.modified_date }}</li>
    <li>Status: {{ issue.status }}</li>
    <li>Type: {{ issue.issue_type }}</li>
    <li>Priority: {{ issue.priority }}</li>


### PR DESCRIPTION
Setting the reporter on issue creation is now built into the request.
This means that we now create issues correctly.

Additionally, I noted that I used DateField instead of DateTimeField
for the timestamps. As a result, we were missing time.  This has been
corrected.

Tested: manually
Reviewed: (during pull)